### PR TITLE
District demographic endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This was built as an independent study project during module 4 at the Turing Sch
 ##### Current Endpoints
 
 * Districts: returns a list of all districts and their county and ESD
+* Demographics:
+  * District: returns student demographics in specified school district & specified school year
 
 ### Production
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class Api::ApiController < ApplicationController
   protect_from_forgery with: :null_session
 end

--- a/app/controllers/api/v1/demographics/districts_controller.rb
+++ b/app/controllers/api/v1/demographics/districts_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::Demographics::DistrictsController < Api::ApiController
+  respond_to :json
+
+  def show
+    district = District.find_by(slug: params["slug"])
+    year = SchoolYear.find_by(years: params["year"])
+    se = StudentEnrollment.where(district_id: district.id, school_year_id: year.id)
+    respond_with se[0], serializer: DistrictDemographicsInYearSerializer
+  end
+end

--- a/app/controllers/api/v1/demographics/districts_controller.rb
+++ b/app/controllers/api/v1/demographics/districts_controller.rb
@@ -4,7 +4,14 @@ class Api::V1::Demographics::DistrictsController < Api::ApiController
   def show
     district = District.find_by(slug: params["slug"])
     year = SchoolYear.find_by(years: params["year"])
-    se = StudentEnrollment.where(district_id: district.id, school_year_id: year.id)
-    respond_with se[0], serializer: DistrictDemographicsInYearSerializer
+    if year && district
+      se = StudentEnrollment.where(district_id: district.id, school_year_id: year.id)
+      respond_with se[0], serializer: DistrictDemographicsInYearSerializer
+    else
+      message = "We do not have data for that combination of school district and school year. Please try another query."
+      status = 400
+      response = { message: message, status: status }.to_json
+      respond_with response
+    end
   end
 end

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -1,4 +1,9 @@
 class District < ActiveRecord::Base
   belongs_to :educational_service_district
   belongs_to :county
+  has_many :student_enrollments
+  has_many :genders,                      through: :student_enrollments
+  has_many :race_ethnicities,             through: :student_enrollments
+  has_many :exceptional_student_services, through: :student_enrollments
+  has_many :other_demographics,           through: :student_enrollments
 end

--- a/app/models/student_enrollment.rb
+++ b/app/models/student_enrollment.rb
@@ -1,8 +1,8 @@
 class StudentEnrollment < ActiveRecord::Base
   belongs_to :school_year
   belongs_to :district
-  has_one :race_ethnicity 
-  has_one :exceptional_student_service 
-  has_one :other_demographic 
-  has_one :gender 
+  has_one :race_ethnicity
+  has_one :exceptional_student_service
+  has_one :other_demographic
+  has_one :gender
 end

--- a/app/models/student_enrollment.rb
+++ b/app/models/student_enrollment.rb
@@ -1,8 +1,8 @@
 class StudentEnrollment < ActiveRecord::Base
   belongs_to :school_year
   belongs_to :district
-  has_one :race_ethnicity
-  has_one :exceptional_student_service
-  has_one :other_demographic
-  has_one :gender
+  has_one    :race_ethnicity
+  has_one    :exceptional_student_service
+  has_one    :other_demographic
+  has_one    :gender
 end

--- a/app/serializers/district_demographics_in_year_serializer.rb
+++ b/app/serializers/district_demographics_in_year_serializer.rb
@@ -1,0 +1,11 @@
+class DistrictDemographicsInYearSerializer< ActiveModel::Serializer
+  has_one :district
+
+  attributes :total,
+             :students_per_classroom_teacher
+
+  has_one :gender
+  has_one :exceptional_student_service
+  has_one :race_ethnicity
+  has_one :other_demographic
+end

--- a/app/serializers/exceptional_student_service_serializer.rb
+++ b/app/serializers/exceptional_student_service_serializer.rb
@@ -1,0 +1,6 @@
+class ExceptionalStudentServiceSerializer < ActiveModel::Serializer
+  attributes :percent_special_education,
+             :number_special_education,
+             :percent_504,
+             :number_504
+end

--- a/app/serializers/gender_serializer.rb
+++ b/app/serializers/gender_serializer.rb
@@ -1,0 +1,3 @@
+class GenderSerializer < ActiveModel::Serializer
+  attributes :percent_male, :number_male, :percent_female, :number_female
+end

--- a/app/serializers/other_demographic_serializer.rb
+++ b/app/serializers/other_demographic_serializer.rb
@@ -1,0 +1,10 @@
+class OtherDemographicSerializer < ActiveModel::Serializer
+  attributes :percent_migrant,
+             :number_migrant,
+             :percent_transitional_bilingual,
+             :number_transitional_bilingual,
+             :percent_frl,
+             :number_frl,
+             :percent_foster_care,
+             :number_foster_care
+end

--- a/app/serializers/race_ethnicity_serializer.rb
+++ b/app/serializers/race_ethnicity_serializer.rb
@@ -1,0 +1,18 @@
+class RaceEthnicitySerializer < ActiveModel::Serializer
+  attributes :percent_american_indian_or_alaskan_native,
+             :number_american_indian_or_alaskan_native,
+             :percent_asian,
+             :number_asian,
+             :percent_pacific_islander,
+             :number_pacific_islander,
+             :percent_asian_pacific_islander,
+             :number_asian_pacific_islander,
+             :percent_black,
+             :number_black,
+             :percent_hispanic,
+             :number_hispanic,
+             :percent_white,
+             :number_white,
+             :percent_two_or_more,
+             :number_two_or_more
+end

--- a/app/serializers/school_year_serializer.rb
+++ b/app/serializers/school_year_serializer.rb
@@ -1,0 +1,3 @@
+class SchoolYearSerializer < ActiveModel::Serializer
+  attributes :years
+end

--- a/app/serializers/student_enrollment_serializer.rb
+++ b/app/serializers/student_enrollment_serializer.rb
@@ -1,0 +1,3 @@
+class StudentEnrollmentSerializer < ActiveModel::Serializer
+  attributes :total, :students_per_classroom_teacher
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
       get '/districts',                           to: 'districts#index'
-      get '/demographics/districts/:slug/:year', to: 'demographics/districts#show'
+      get '/demographics/districts',  to: 'demographics/districts#show'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      get '/districts', to: 'districts#index'
+      get '/districts',                           to: 'districts#index'
+      get '/demographics/districts/:slug/:year', to: 'demographics/districts#show'
     end
   end
 end

--- a/lib/swagger/swagger_v1.json
+++ b/lib/swagger/swagger_v1.json
@@ -30,6 +30,55 @@
                     }
                 }
             }
+        },
+        "/demographics/districts": {
+            "get": {
+                "summary": "Student demographics for district and year",
+                "description": "This endpoint returns the gender, race & ethnicity, students who receive exceptional student services, and other demographic information on all students in the specified school district for the specified school year. School district name should be passed as the parameterized version (slug). The school year should be passed as the full year for the starting year, and the last two digits of the ending year. This can only span one school year. For example - '2016-17'",
+                "parameters": [
+                    {
+                        "name": "slug",
+                        "in": "query",
+                        "description": "slug of school district name",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "description": "slug of school district name",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful response",
+                        "schema": {
+                            "$ref": "#/definitions/DistrictDemographics"
+                        }
+                    },
+                    "400": {
+                        "description": "Data does not exist for the specified combination of school district and school year",
+                        "schema": {
+                            "type": "object",
+                            "description": "contains error message and status code",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "specific error"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "description": "400 status code"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -69,6 +118,189 @@
                         "slug": {
                             "type": "string",
                             "description": "Parameterized name of the county. To be used for any calls requesting data for a specific County"
+                        }
+                    }
+                }
+            }
+        },
+        "DistrictDemographics": {
+            "type": "object",
+            "properties": {
+                "total": {
+                    "type": "integer",
+                    "description": "Total number of students enrolled in the district"
+                },
+                "students_per_classroom_teacher": {
+                    "type": "integer",
+                    "description": "Average number of students per classroom teacher"
+                },
+                "district": {
+                    "type": "object",
+                    "description": "details about the specific district requested",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the school district"
+                        },
+                        "slug": {
+                            "type": "string",
+                            "description": "Parameterized name of the school district"
+                        },
+                        "number": {
+                            "type": "string",
+                            "description": "Number used to identify school district"
+                        }
+                    }
+                },
+                "gender": {
+                    "type": "object",
+                    "description": "Detailed gender demographics",
+                    "properties": {
+                        "percent_male": {
+                            "type": "integer",
+                            "description": "Percent of students who are male"
+                        },
+                        "number_male": {
+                            "type": "integer",
+                            "description": "Nubmer of students who are male"
+                        },
+                        "percent_female": {
+                            "type": "integer",
+                            "description": "Percent of students who are female"
+                        },
+                        "number_female": {
+                            "type": "integer",
+                            "description": "Number of students who are female"
+                        }
+                    }
+                },
+                "exceptional_student_service": {
+                    "type": "object",
+                    "description": "Detailed statistics for students who receive exceptional student services",
+                    "properties": {
+                        "percent_special_education": {
+                            "type": "integer",
+                            "description": "Percent of students who receive special education services"
+                        },
+                        "nubmer_special_education": {
+                            "type": "integer",
+                            "description": "Number of students who receive special education services"
+                        },
+                        "percent_504": {
+                            "type": "integer",
+                            "description": "Percent of students who receive services from a Section 504 plan"
+                        },
+                        "number_504": {
+                            "type": "integer",
+                            "description": "Number of students who receive services from a Section 504 plan"
+                        }
+                    }
+                },
+                "race_ethnicity": {
+                    "type": "object",
+                    "description": "Detailed statistics on race and ethnicity of students as identified by parents",
+                    "properties": {
+                        "percent_american_indian_or_alaskan_native": {
+                            "type": "integer",
+                            "description": "Percent of students identified as American Indian or Alaskan Native"
+                        },
+                        "number_american_indian_or_alaskan_native": {
+                            "type": "integer",
+                            "description": "Number of students identified as American Indian or Alaskan Native"
+                        },
+                        "percent_asian": {
+                            "type": "integer",
+                            "description": "Percent of students identified as Asian"
+                        },
+                        "number_asian": {
+                            "type": "integer",
+                            "description": "Number of students identified as Asian"
+                        },
+                        "percent_pacific_islander": {
+                            "type": "integer",
+                            "description": "Percent of students identified as Pacific Islander"
+                        },
+                        "number_pacific_islander": {
+                            "type": "integer",
+                            "description": "Number of students identified as Pacific Islander"
+                        },
+                        "percent_asian_pacific_islander": {
+                            "type": "integer",
+                            "description": "Percent of students identified as Asian Pacific Islander"
+                        },
+                        "number_asian_pacific_islander": {
+                            "type": "integer",
+                            "description": "Number of students identified as Asian Pacific Islander"
+                        },
+                        "percent_black": {
+                            "type": "integer",
+                            "description": "Percent of students identified as Black"
+                        },
+                        "number_black": {
+                            "type": "integer",
+                            "description": "Number of students identified as Black"
+                        },
+                        "percent_hispanic": {
+                            "type": "integer",
+                            "description": "Percent of students identified as Hispanic"
+                        },
+                        "number_hispanic": {
+                            "type": "integer",
+                            "description": "Number of students identified as Hispanic"
+                        },
+                        "percent_white": {
+                            "type": "integer",
+                            "description": "Percent of students identified as White"
+                        },
+                        "number_white": {
+                            "type": "integer",
+                            "description": "Number of students identified as White"
+                        },
+                        "percent_two_or_more": {
+                            "type": "integer",
+                            "description": "Percent of students identified as two or more races"
+                        },
+                        "number_two_or_more": {
+                            "type": "integer",
+                            "description": "Number of students identified as two or more races"
+                        }
+                    }
+                },
+                "other_demographic": {
+                    "type": "object",
+                    "description": "other demographic indicators",
+                    "properties": {
+                        "percent_migrant": {
+                            "type": "integer",
+                            "description": "Percent of students identified as migrant"
+                        },
+                        "nubmer_migrant": {
+                            "type": "integer",
+                            "description": "Number of students identified as migrant"
+                        },
+                        "percent_transitional_bilingual": {
+                            "type": "integer",
+                            "description": "Percent of students identified as transitional bilingual"
+                        },
+                        "nubmer_transitional_bilingual": {
+                            "type": "integer",
+                            "description": "Number of students identified as transitional bilingual"
+                        },
+                        "percent_frl": {
+                            "type": "integer",
+                            "description": "Percent of students who receive Free or Reduced Price Meals"
+                        },
+                        "nubmer_frl": {
+                            "type": "integer",
+                            "description": "Number of students who receive Free or Reduced Price Meals"
+                        },
+                        "percent_foster_care": {
+                            "type": "integer",
+                            "description": "Percent of students currently living in foster care"
+                        },
+                        "nubmer_foster_care": {
+                            "type": "integer",
+                            "description": "Number of students currently living in foster care"
                         }
                     }
                 }

--- a/spec/controller/demographics/districts_controller_spec.rb
+++ b/spec/controller/demographics/districts_controller_spec.rb
@@ -66,5 +66,47 @@ RSpec.describe Api::V1::Demographics::DistrictsController, type: :controller do
 
       expect(district_demographics).to eq(result)
     end
+
+    it "responds with error if school year doesn't exist" do
+      sy = SchoolYear.create(years: "2015-16")
+      c = County.create(name: "King", number: "17", slug: "king")
+      esd = EducationalServiceDistrict.create(name: "Puget Sound Educational Service District 121", slug: "puget-sound-educational-service-district-121")
+      d = District.create(name: "Auburn School District", number: "17408", educational_service_district_id: esd.id, county_id: c.id, slug: "auburn-school-district")
+      se = StudentEnrollment.create(school_year_id: sy.id, total: 1378, students_per_classroom_teacher: 18, district_id: d.id)
+      Gender.create(percent_male: 49, number_male: 73, percent_female: 51, number_female: 82, student_enrollment_id: se.id)
+      OtherDemographic.create(percent_migrant: 2.42, number_migrant: 73, percent_transitional_bilingual: 14.83, number_transitional_bilingual: 37, percent_frl: 37.34, number_frl: 145, percent_foster_care: 2.04, number_foster_care: 31, student_enrollment_id: se.id)
+      ExceptionalStudentService.create(percent_special_education: 10, number_special_education: 181, percent_504: 7.56, number_504: 147, student_enrollment_id: se.id)
+      RaceEthnicity.create(percent_american_indian_or_alaskan_native: 2.03, number_american_indian_or_alaskan_native: 28, percent_asian: 14.30, number_asian: 94, percent_pacific_islander: 2.32, number_pacific_islander: 83, percent_asian_pacific_islander: 8.32, number_asian_pacific_islander: 23, percent_black: 42.12, number_black: 123, percent_hispanic: 13.42, number_hispanic: 983, percent_white: 12, number_white: 193, percent_two_or_more: 12.3, number_two_or_more: 412, student_enrollment_id: se.id)
+
+      get :show, slug: d.slug, year: "2014-15", format: :json
+
+      expected_response = {
+        message: "We do not have data for that combination of school district and school year. Please try another query.",
+        status: 400
+      }.to_json
+
+      expect(response.body).to eq(expected_response)
+    end
+
+    it "responds with error if school district doesn't exist" do
+      sy = SchoolYear.create(years: "2015-16")
+      c = County.create(name: "King", number: "17", slug: "king")
+      esd = EducationalServiceDistrict.create(name: "Puget Sound Educational Service District 121", slug: "puget-sound-educational-service-district-121")
+      d = District.create(name: "Auburn School District", number: "17408", educational_service_district_id: esd.id, county_id: c.id, slug: "auburn-school-district")
+      se = StudentEnrollment.create(school_year_id: sy.id, total: 1378, students_per_classroom_teacher: 18, district_id: d.id)
+      Gender.create(percent_male: 49, number_male: 73, percent_female: 51, number_female: 82, student_enrollment_id: se.id)
+      OtherDemographic.create(percent_migrant: 2.42, number_migrant: 73, percent_transitional_bilingual: 14.83, number_transitional_bilingual: 37, percent_frl: 37.34, number_frl: 145, percent_foster_care: 2.04, number_foster_care: 31, student_enrollment_id: se.id)
+      ExceptionalStudentService.create(percent_special_education: 10, number_special_education: 181, percent_504: 7.56, number_504: 147, student_enrollment_id: se.id)
+      RaceEthnicity.create(percent_american_indian_or_alaskan_native: 2.03, number_american_indian_or_alaskan_native: 28, percent_asian: 14.30, number_asian: 94, percent_pacific_islander: 2.32, number_pacific_islander: 83, percent_asian_pacific_islander: 8.32, number_asian_pacific_islander: 23, percent_black: 42.12, number_black: 123, percent_hispanic: 13.42, number_hispanic: 983, percent_white: 12, number_white: 193, percent_two_or_more: 12.3, number_two_or_more: 412, student_enrollment_id: se.id)
+
+      get :show, slug: 'fake-school-district', year: "2015-16", format: :json
+
+      expected_response = {
+        message: "We do not have data for that combination of school district and school year. Please try another query.",
+        status: 400
+      }.to_json
+
+      expect(response.body).to eq(expected_response)
+    end
   end
 end

--- a/spec/controller/demographics/districts_controller_spec.rb
+++ b/spec/controller/demographics/districts_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Demographics::DistrictsController, type: :controller do
+  describe "GET show" do
+    it "returns a specific districts demographic information" do
+      sy = SchoolYear.create(years: "2015-2016")
+      c = County.create(name: "King", number: "17", slug: "king")
+      esd = EducationalServiceDistrict.create(name: "Puget Sound Educational Service District 121", slug: "puget-sound-educational-service-district-121")
+      d = District.create(name: "Auburn School District", number: "17408", educational_service_district_id: esd.id, county_id: c.id, slug: "auburn-school-district")
+      se = StudentEnrollment.create(school_year_id: sy.id, total: 1378, students_per_classroom_teacher: 18, district_id: d.id)
+      g = Gender.create(percent_male: 49, number_male: 73, percent_female: 51, number_female: 82, student_enrollment_id: se.id)
+      od = OtherDemographic.create(percent_migrant: 2.42, number_migrant: 73, percent_transitional_bilingual: 14.83, number_transitional_bilingual: 37, percent_frl: 37.34, number_frl: 145, percent_foster_care: 2.04, number_foster_care: 31, student_enrollment_id: se.id)
+      ess = ExceptionalStudentService.create(percent_special_education: 10, number_special_education: 181, percent_504: 7.56, number_504: 147, student_enrollment_id: se.id)
+      re = RaceEthnicity.create(percent_american_indian_or_alaskan_native: 2.03, number_american_indian_or_alaskan_native: 28, percent_asian: 14.30, number_asian: 94, percent_pacific_islander: 2.32, number_pacific_islander: 83, percent_asian_pacific_islander: 8.32, number_asian_pacific_islander: 23, percent_black: 42.12, number_black: 123, percent_hispanic: 13.42, number_hispanic: 983, percent_white: 12, number_white: 193, percent_two_or_more: 12.3, number_two_or_more: 412, student_enrollment_id: se.id)
+
+      get :show, slug: d.slug, year: sy.years, format: :json
+      district_demographics = JSON.parse(response.body)
+      result = {
+        "total" => se.total,
+        "students_per_classroom_teacher" => se.students_per_classroom_teacher,
+        "district" => {
+          "name" => d.name,
+          "slug" => d.slug,
+          "number" => d.number,
+        },
+        "gender" => {
+          "percent_male" => g.percent_male,
+          "number_male" => g.number_male,
+          "percent_female" => g.percent_female,
+          "number_female" => g.number_female
+        },
+        "exceptional_student_service" => {
+          "percent_special_education" => ess.percent_special_education,
+          "number_special_education" => ess.number_special_education,
+          "percent_504" => ess.percent_504,
+          "number_504" => ess.number_504
+        },
+        "race_ethnicity" => {
+          "percent_american_indian_or_alaskan_native" => re.percent_american_indian_or_alaskan_native,
+          "number_american_indian_or_alaskan_native" => re.number_american_indian_or_alaskan_native,
+          "percent_asian" => re.percent_asian,
+          "number_asian" => re.number_asian,
+          "percent_pacific_islander" => re.percent_pacific_islander,
+          "number_pacific_islander" => re.number_pacific_islander,
+          "percent_asian_pacific_islander" => re.percent_asian_pacific_islander,
+          "number_asian_pacific_islander" => re.number_asian_pacific_islander,
+          "percent_black" => re.percent_black,
+          "number_black" => re.number_black,
+          "percent_hispanic" => re.percent_hispanic,
+          "number_hispanic" => re.number_hispanic,
+          "percent_white" => re.percent_white,
+          "number_white" => re.number_white,
+          "percent_two_or_more" => re.percent_two_or_more,
+          "number_two_or_more" => re.number_two_or_more},
+        "other_demographic" => {
+          "percent_migrant" => od.percent_migrant,
+          "number_migrant" => od.number_migrant,
+          "percent_transitional_bilingual" => od.percent_transitional_bilingual,
+          "number_transitional_bilingual" => od.number_transitional_bilingual,
+          "percent_frl" => od.percent_frl,
+          "number_frl" => od.number_frl,
+          "percent_foster_care" => od.percent_foster_care,
+          "number_foster_care" => od.number_foster_care
+        }
+      }
+
+      expect(district_demographics).to eq(result)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'json'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|


### PR DESCRIPTION
Creates new endpoint to retrieve demographic data for a specified school district in a given school year, adds endpoint documentation to swagger.json (includes error handling, parameters). Uses several new serializers for formatting data. 

Error handling may not currently meet best practices; we will have a class on this next week, so may update that then

Swagger documentation does not work properly in development because it expects https for the "try it out" functionality

@geopet

I'm going to go ahead and merge this in so I can work off of it, but nothing is so set in stone that additional feedback won't help!

Background: 
This: https://github.com/adriennedomingus/wadoe_api/pull/4 PR includes an image of the schema

