### PR TITLE
Improve error messaging for district demographics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ This app serves an API using data from the Washington State Department of Educat
 
 This was built as an independent study project during module 4 at the Turing School of Software and Design.
 
+** This API is still in development - it is not guaranteed to be continually backward compatible **
+
 ##### Current Endpoints
 
 * Districts: returns a list of all districts and their county and ESD
 * Demographics:
   * District: returns student demographics in specified school district & specified school year
+  * Data is currently available for the 2008 - 2009 school year through the 2014-2015 school year
 
 ### Production
 

--- a/app/controllers/api/v1/demographics/districts_controller.rb
+++ b/app/controllers/api/v1/demographics/districts_controller.rb
@@ -4,14 +4,36 @@ class Api::V1::Demographics::DistrictsController < Api::ApiController
   def show
     district = District.find_by(slug: params["slug"])
     year = SchoolYear.find_by(years: params["year"])
-    if year && district
+    if invalid_request(district, year)
+      message = invalid_request(district, year)
+      response = { message: message, status: 404 }.to_json
+      respond_with response, status: 404
+    else
       student_enrollment = StudentEnrollment.where(district_id: district.id, school_year_id: year.id)
       respond_with student_enrollment[0], serializer: DistrictDemographicsInYearSerializer
-    else
-      message = "We do not have data for that combination of school district and school year. Please try another query."
-      status = 400
-      response = { message: message, status: status }.to_json
-      respond_with response
     end
   end
+
+  private
+    def invalid_request(district, year)
+      if invalid_district_and_year(district, year)
+        "We do not have data for that school district or school year. Please try another query."
+      elsif invalid_school_district(district, year)
+        "We do not have that school district in our system. Please try another query"
+      elsif invalid_school_year(district, year)
+        "We do not have data for that school year. Please try another query."
+      end
+    end
+
+    def invalid_district_and_year(district, year)
+      !year && !district
+    end
+
+    def invalid_school_district(district, year)
+      year && !district
+    end
+
+    def invalid_school_year(district, year)
+      !year && district
+    end
 end

--- a/lib/swagger/swagger_v1.json
+++ b/lib/swagger/swagger_v1.json
@@ -67,8 +67,8 @@
                             "$ref": "#/definitions/DistrictDemographics"
                         }
                     },
-                    "400": {
-                        "description": "Data does not exist for the specified combination of school district and school year",
+                    "404": {
+                        "description": "Data does not exist for the specified combination of school district and school year. Includes specifics for which parameter could not be found",
                         "schema": {
                             "type": "object",
                             "description": "contains error message and status code",
@@ -79,7 +79,7 @@
                                 },
                                 "status": {
                                     "type": "string",
-                                    "description": "400 status code"
+                                    "description": "404 status code"
                                 }
                             }
                         }

--- a/spec/controller/demographics/districts_controller_spec.rb
+++ b/spec/controller/demographics/districts_controller_spec.rb
@@ -57,19 +57,22 @@ RSpec.describe Api::V1::Demographics::DistrictsController, type: :controller do
       }
 
       expect(district_demographics).to eq(result)
+      expect(response.code).to eq("200")
+
     end
 
     it "responds with error if school year doesn't exist" do
-      _, _, _, d = create_district_and_data
+      _, _, _, district = create_district_and_data
 
-      get :show, slug: d.slug, year: "2014-15", format: :json
+      get :show, slug: district.slug, year: "2014-15", format: :json
 
       expected_response = {
-        message: "We do not have data for that combination of school district and school year. Please try another query.",
-        status: 400
+        message: "We do not have data for that school year. Please try another query.",
+        status: 404
       }.to_json
 
       expect(response.body).to eq(expected_response)
+      expect(response.code).to eq("404")
     end
 
     it "responds with error if school district doesn't exist" do
@@ -78,11 +81,12 @@ RSpec.describe Api::V1::Demographics::DistrictsController, type: :controller do
       get :show, slug: 'fake-school-district', year: "2015-16", format: :json
 
       expected_response = {
-        message: "We do not have data for that combination of school district and school year. Please try another query.",
-        status: 400
+        message: "We do not have that school district in our system. Please try another query",
+        status: 404
       }.to_json
 
       expect(response.body).to eq(expected_response)
+      expect(response.code).to eq("404")
     end
   end
 end

--- a/spec/controller/districts_controller_spec.rb
+++ b/spec/controller/districts_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Api::V1::DistrictsController, type: :controller do
                   }]
 
       expect(districts).to eq(result)
+      expect(response.code).to eq("200")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ SimpleCov.start 'rails'
 
 module SpecHelpers
   def create_district_and_data
-    school_year = SchoolYear.create(years: "2015-2016")
+    school_year = SchoolYear.create(years: "2015-16")
     county = County.create(name: "King", number: "17", slug: "king")
     educational_service_district = EducationalServiceDistrict.create(name: "Puget Sound Educational Service District 121", slug: "puget-sound-educational-service-district-121")
     district = District.create(name: "Auburn School District", number: "17408", educational_service_district_id: educational_service_district.id, county_id: county.id, slug: "auburn-school-district")


### PR DESCRIPTION
Differing error messages based on issue
Return 404 status code instead of just including it in response

@geopet

Method is still a bit long, but more readable and informative. Thoughts?