### PR TITLE
Remove duplication from controllers

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -11,4 +11,43 @@ class Api::ApiController < ApplicationController
     message = "Please include a valid API key with your request"
     { message: message, status: 401 }.to_json
   end
+
+  def invalid_request(district, year)
+    if invalid_district_and_year(district, year)
+      "We do not have data for that school district or school year. Please try another query."
+    elsif invalid_school_district(district, year)
+      "We do not have that school district in our system. Please try another query"
+    elsif invalid_school_year(district, year)
+      "We do not have data for that school year. Please try another query."
+    end
+  end
+
+  def district_in_year_repsonse(params, serializer)
+    district = District.find_by(slug: params["slug"])
+    year = SchoolYear.find_by(years: params["year"])
+    key = params[:api_key]
+    if invalid_request(district, year)
+      message = invalid_request(district, year)
+      response = { message: message, status: 404 }.to_json
+      [response, {status: 404} ]
+    elsif authenticated_api_key?(key)
+      district_school_year = DistrictSchoolYear.find_by(district_id: district.id, school_year_id: year.id)
+      [district_school_year, { serializer: serializer }]
+    else
+      [unauthorized_response, { status: 401, head: :unauthorized }]
+    end
+  end
+
+  private
+  def invalid_district_and_year(district, year)
+    !year && !district
+  end
+
+  def invalid_school_district(district, year)
+    year && !district
+  end
+
+  def invalid_school_year(district, year)
+    !year && district
+  end
 end

--- a/app/controllers/api/v1/demographics/districts_controller.rb
+++ b/app/controllers/api/v1/demographics/districts_controller.rb
@@ -2,41 +2,7 @@ class Api::V1::Demographics::DistrictsController < Api::ApiController
   respond_to :json
 
   def show
-    district = District.find_by(slug: params["slug"])
-    year = SchoolYear.find_by(years: params["year"])
-    key = params[:api_key]
-    if invalid_request(district, year)
-      message = invalid_request(district, year)
-      response = { message: message, status: 404 }.to_json
-      respond_with response, status: 404
-    elsif authenticated_api_key?(key)
-      district_school_year = DistrictSchoolYear.find_by(district_id: district.id, school_year_id: year.id)
-      respond_with district_school_year, serializer: DistrictSchoolYearDemographicsSerializer
-    else
-      respond_with unauthorized_response, status: 401, head: :unauthorized
-    end
+    message, options = district_in_year_repsonse(params, DistrictSchoolYearDemographicsSerializer)
+    respond_with message, options
   end
-
-  private
-    def invalid_request(district, year)
-      if invalid_district_and_year(district, year)
-        "We do not have data for that school district or school year. Please try another query."
-      elsif invalid_school_district(district, year)
-        "We do not have that school district in our system. Please try another query"
-      elsif invalid_school_year(district, year)
-        "We do not have data for that school year. Please try another query."
-      end
-    end
-
-    def invalid_district_and_year(district, year)
-      !year && !district
-    end
-
-    def invalid_school_district(district, year)
-      year && !district
-    end
-
-    def invalid_school_year(district, year)
-      !year && district
-    end
 end

--- a/app/controllers/api/v1/graduation/districts_controller.rb
+++ b/app/controllers/api/v1/graduation/districts_controller.rb
@@ -2,41 +2,7 @@ class Api::V1::Graduation::DistrictsController < Api::ApiController
   respond_to :json
 
   def show
-    district = District.find_by(slug: params["slug"])
-    year = SchoolYear.find_by(years: params["year"])
-    key = params[:api_key]
-    if invalid_request(district, year)
-      message = invalid_request(district, year)
-      response = { message: message, status: 404 }.to_json
-      respond_with response, status: 404
-    elsif authenticated_api_key?(key)
-      district_school_year = DistrictSchoolYear.find_by(district_id: district.id, school_year_id: year.id)
-      respond_with district_school_year, serializer: DistrictSchoolYearGraduationSerializer
-    else
-      respond_with unauthorized_response, status: 401, head: :unauthorized
-    end
+    message, options = district_in_year_repsonse(params, DistrictSchoolYearGraduationSerializer)
+    respond_with message, options
   end
-
-  private
-    def invalid_request(district, year)
-      if invalid_district_and_year(district, year)
-        "We do not have data for that school district or school year. Please try another query."
-      elsif invalid_school_district(district, year)
-        "We do not have that school district in our system. Please try another query"
-      elsif invalid_school_year(district, year)
-        "We do not have data for that school year. Please try another query."
-      end
-    end
-
-    def invalid_district_and_year(district, year)
-      !year && !district
-    end
-
-    def invalid_school_district(district, year)
-      year && !district
-    end
-
-    def invalid_school_year(district, year)
-      !year && district
-    end
 end


### PR DESCRIPTION
Both show actions had the same responses, just using different serializers. Pulled into the API controller where both can reference the same methods.