### PR TITLE
Params to graduation

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -32,7 +32,11 @@ class Api::ApiController < ApplicationController
       [response, {status: 404} ]
     elsif authenticated_api_key?(key)
       district_school_year = DistrictSchoolYear.find_by(district_id: district.id, school_year_id: year.id)
-      [district_school_year, { serializer: serializer }]
+      if params[:graduation_tag]
+        [district_school_year, serializer: serializer, scope: params[:graduation_tag]]
+      else
+        [district_school_year, { serializer: serializer }]
+      end
     else
       [unauthorized_response, { status: 401, head: :unauthorized }]
     end

--- a/app/serializers/district_school_year_graduation_serializer.rb
+++ b/app/serializers/district_school_year_graduation_serializer.rb
@@ -4,32 +4,57 @@ class DistrictSchoolYearGraduationSerializer < ActiveModel::Serializer
   attributes :graduation
 
   def graduation
+    tag_from_params = Tag.find_by(name: scope)
+    if tag_from_params
+      specific_tag_response(tag_from_params)
+    else
+      all_tags_response
+    end
+  end
+
+  def response_hash(five_year_graduation_rate)
+    { began_9_in_wa: five_year_graduation_rate.began_9_in_wa,
+      transferred_into_wa: five_year_graduation_rate.transferred_in,
+      transferred_out: five_year_graduation_rate.transferred_out,
+      adjusted_cohort: five_year_graduation_rate.adjusted_cohort,
+      graduates: five_year_graduation_rate.graduates,
+      continuing: five_year_graduation_rate.continuing,
+      adjusted_five_year_cohort_graduation_rate: five_year_graduation_rate.adjusted_five_year_cohort_graduation_rate,
+      cohort_dropout_rate: five_year_graduation_rate.cohort_dropout_rate,
+      continuing_rate: five_year_graduation_rate.continuing_rate,
+      dropouts: {
+        year1: five_year_graduation_rate.dropout.year_1,
+        year2: five_year_graduation_rate.dropout.year_2,
+        year3: five_year_graduation_rate.dropout.year_3,
+        year4: five_year_graduation_rate.dropout.year_4,
+        year5: five_year_graduation_rate.dropout.year_5
+        }}
+  end
+
+  def specific_tag_response(tag_from_params)
+    custom_tag = {tag_from_params.name => {}}
+    tag_from_params.student_identifiers.each do |si|
+      add_statistics_to_tag(custom_tag, si, tag_from_params)
+    end
+    [custom_tag]
+  end
+
+  def all_tags_response
     all_tags = []
     object.tags.each do |tag|
       custom_tag = {tag.name => {}}
       tag.student_identifiers.each do |si|
-        five_year_graduation_rate = si.five_year_graduation_rates.where(district_school_year_id: object.id)[0]
-        if five_year_graduation_rate
-          custom_tag[tag.name][si.name] = { began_9_in_wa: five_year_graduation_rate.began_9_in_wa,
-                                            transferred_into_wa: five_year_graduation_rate.transferred_in,
-                                            transferred_out: five_year_graduation_rate.transferred_out,
-                                            adjusted_cohort: five_year_graduation_rate.adjusted_cohort,
-                                            graduates: five_year_graduation_rate.graduates,
-                                            continuing: five_year_graduation_rate.continuing,
-                                            adjusted_five_year_cohort_graduation_rate: five_year_graduation_rate.adjusted_five_year_cohort_graduation_rate,
-                                            cohort_dropout_rate: five_year_graduation_rate.cohort_dropout_rate,
-                                            continuing_rate: five_year_graduation_rate.continuing_rate,
-                                            dropouts: {
-                                              year1: five_year_graduation_rate.dropout.year_1,
-                                              year2: five_year_graduation_rate.dropout.year_2,
-                                              year3: five_year_graduation_rate.dropout.year_3,
-                                              year4: five_year_graduation_rate.dropout.year_4,
-                                              year5: five_year_graduation_rate.dropout.year_5
-                                              }}
-        end
+        add_statistics_to_tag(custom_tag, si, tag)
       end
       all_tags.push(custom_tag)
     end
     all_tags.uniq
+  end
+
+  def add_statistics_to_tag(custom_tag, si, tag)
+    five_year_graduation_rate = si.five_year_graduation_rates.where(district_school_year_id: object.id)[0]
+    if five_year_graduation_rate
+      custom_tag[tag.name][si.name] = response_hash(five_year_graduation_rate)
+    end
   end
 end

--- a/lib/swagger/swagger_v1.json
+++ b/lib/swagger/swagger_v1.json
@@ -17,7 +17,7 @@
         "/districts": {
             "get": {
                 "summary": "List of all districts",
-                "description": "This endpoint returns all school districts and includes its name, slug(used for querying about an individual district) and number, as well as the name and basic enrollment data. Data is currently only available for the 2013-14 school year, but more will be added shortly.",
+                "description": "This endpoint returns all school districts and includes its name, slug(used for querying about an individual district) and number, as well as the name and",
                 "parameters": [
                     {
                         "name": "api_key",
@@ -64,7 +64,7 @@
         "/demographics/district-in-year": {
             "get": {
                 "summary": "Student demographics for specified district in given year",
-                "description": "This endpoint returns the gender, race & ethnicity, students who receive exceptional student services, and other demographic information on all students in the specified school district for the specified school year. School district name should be passed as the parameterized version (slug). The school year should be passed as the full year for the starting year, and the last two digits of the ending year. This can only span one school year. For example - '2016-17'. Data is currently available from the 2010-11 school year through the 2013-14 school year.",
+                "description": "This endpoint returns the gender, race & ethnicity, students who receive exceptional student services, and other demographic information on all students in the specified school district for the specified school year. School district name should be passed as the parameterized version (slug). The school year should be passed as the full year for the starting year, and the last two digits of the ending year. This can only span one school year. For example - '2016-17'",
                 "parameters": [
                     {
                         "name": "slug",
@@ -142,7 +142,7 @@
         "/graduation/district-in-year": {
             "get": {
                 "summary": "Five year graduation rates for the specified school district and year",
-                "description": "This endpoint returns the gender, race & ethnicity, students who receive exceptional student services, and other demographic information on all students in the specified school district for the specified school year. School district name should be passed as the parameterized version (slug). The school year should be passed as the full year for the starting year, and the last two digits of the ending year. This can only span one school year. For example - '2016-17' (This year would produce results for the class of 2016). Data is currently available from the 2010-11 school year through the 2013-14 school year.",
+                "description": "This endpoint returns the gender, race & ethnicity, students who receive exceptional student services, and other demographic information on all students in the specified school district for the specified school year. School district name should be passed as the parameterized version (slug). The school year should be passed as the full year for the starting year, and the last two digits of the ending year. This can only span one school year. For example - '2016-17' (This year would produce results for the class of 2016)",
                 "parameters": [
                     {
                         "name": "slug",
@@ -165,6 +165,14 @@
                         "in": "query",
                         "description": "your individual api key",
                         "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "graduation_tag",
+                        "in": "query",
+                        "description": "name of tag you would like response to be scoped by. Options are - 'all', 'race%20ethnicity', 'other', 'gender', 'exceptional%20student%20services'. Limit 1.",
+                        "required": false,
                         "type": "string",
                         "format": "uuid"
                     }

--- a/lib/swagger/swagger_v1.json
+++ b/lib/swagger/swagger_v1.json
@@ -17,7 +17,7 @@
         "/districts": {
             "get": {
                 "summary": "List of all districts",
-                "description": "This endpoint returns all school districts and includes its name, slug(used for querying about an individual district) and number, as well as the name and",
+                "description": "This endpoint returns all school districts and includes its name, slug(used for querying about an individual district) and number, as well as the name and basic enrollment data",
                 "parameters": [
                     {
                         "name": "api_key",

--- a/spec/controller/graduation/districts_controller_spec.rb
+++ b/spec/controller/graduation/districts_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Graduation::DistrictsController, type: :controller do
   describe "GET show" do
-    it "returns a specific districts demographic information" do
+    it "returns a specific districts graduation statistics" do
       user = User.create(email: "example@example.com", password: "password", api_key: "abc123")
       school_year, _, _, district = create_district_and_demographic_data
 
@@ -12,6 +12,23 @@ RSpec.describe Api::V1::Graduation::DistrictsController, type: :controller do
 
       expect(district_demographics["graduation"]).to be_truthy
       expect(district_demographics["graduation"][1]["race ethnicity"]["asian"]["transferred_out"]).to be_truthy
+      expect(district_demographics["graduation"][3]["exceptional student services"]).to be_truthy
+      expect(district_demographics["graduation"][4]["all"]).to be_truthy
+      expect(district_demographics["graduation"][2]["other"]).to be_truthy
+      expect(district_demographics["graduation"][0]["gender"]).to be_truthy
+      expect(response.code).to eq("200")
+    end
+
+    it "returns a specific districts graduation statistics scoped by tag" do
+      user = User.create(email: "example@example.com", password: "password", api_key: "abc123")
+      school_year, _, _, district = create_district_and_demographic_data
+
+      get :show, slug: district.slug, year: school_year.years, api_key: user.api_key, graduation_tag: "race ethnicity", format: :json
+      district_demographics = JSON.parse(response.body)
+
+      expect(district_demographics["graduation"]).to be_truthy
+      expect(district_demographics["graduation"][0]["race ethnicity"]["asian"]["transferred_out"]).to be_truthy
+      expect(district_demographics["graduation"][1]).to be_falsy
       expect(response.code).to eq("200")
     end
 


### PR DESCRIPTION
Allows a user to pass a specific tag to the graduation statistics request to only return statistics for a specific tag. Tag is optional, and currently scoped to one tag, but may add the option to include multiple moving forward. 