### PR TITLE
Add pagination to district response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'responders', '~> 2.0'
 gem 'swagger_engine'
 gem 'rails_12factor', group: :production
 gem 'bcrypt', '~> 3.1.7'
+gem 'will_paginate'
+gem 'api-pagination'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    api-pagination (4.3.0)
     arel (6.0.3)
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
@@ -203,6 +204,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    will_paginate (3.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -211,6 +213,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers!
+  api-pagination
   bcrypt (~> 3.1.7)
   byebug
   capybara
@@ -233,6 +236,7 @@ DEPENDENCIES
   swagger_engine
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate
 
 BUNDLED WITH
    1.11.2

--- a/app/controllers/api/v1/districts_controller.rb
+++ b/app/controllers/api/v1/districts_controller.rb
@@ -4,7 +4,9 @@ class Api::V1::DistrictsController < Api::ApiController
   def index
     key = params[:api_key]
     if authenticated_api_key?(key)
-      respond_with District.all
+      districts = District.all
+      districts_per_page = params[:per_page] || 25
+      paginate json: districts, per_page: districts_per_page
     else
       respond_with unauthorized_response, status: 401, head: :unauthorized
     end

--- a/lib/swagger/swagger_v1.json
+++ b/lib/swagger/swagger_v1.json
@@ -26,6 +26,22 @@
                         "required": true,
                         "type": "string",
                         "format": "uuid"
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "the number of objects you would like returned on each page. Defaults to 25 if not provided",
+                        "required": false,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "which page of the response you would like returned. Defaults to 1 if not provided",
+                        "required": false,
+                        "type": "string",
+                        "format": "uuid"
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
Not added to demographic or graduation responses since only one object is returned