### PR TITLE
State demographic endpoint

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -58,8 +58,6 @@ class Api::ApiController < ApplicationController
         [object_school_year, serializer: serializer, scope: params[:graduation_tag]]
       elsif serializer
         [object_school_year, { serializer: serializer }]
-      else
-        object_school_year
       end
     end
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -47,6 +47,8 @@ class Api::ApiController < ApplicationController
         return_object = DistrictSchoolYear.find_by(district_id: object.id, school_year_id: year.id)
       elsif object.class == County
         return_object = CountySchoolYear.find_by(county_id: object.id, school_year_id: year.id)
+      else
+        return_object = State.new(year.years)
       end
       response_object(return_object, serializer, params)
     end
@@ -54,8 +56,10 @@ class Api::ApiController < ApplicationController
     def response_object(object_school_year, serializer, params)
       if params[:graduation_tag]
         [object_school_year, serializer: serializer, scope: params[:graduation_tag]]
-      else
+      elsif serializer
         [object_school_year, { serializer: serializer }]
+      else
+        object_school_year
       end
     end
 

--- a/app/controllers/api/v1/demographics/state_controller.rb
+++ b/app/controllers/api/v1/demographics/state_controller.rb
@@ -1,10 +1,6 @@
 class Api::V1::Demographics::StateController < Api::ApiController
   respond_to :json
 
-  # def show
-  #   respond_with State.new(params[:year])
-  # end
-
   def show
     message, options = response_path(State.new(params[:year]), StateSerializer, params)
     respond_with message, options

--- a/app/controllers/api/v1/demographics/state_controller.rb
+++ b/app/controllers/api/v1/demographics/state_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Demographics::StateController < Api::ApiController
+  respond_to :json
+
+  def show
+    respond_with State.new(params[:year])
+  end
+end

--- a/app/controllers/api/v1/demographics/state_controller.rb
+++ b/app/controllers/api/v1/demographics/state_controller.rb
@@ -1,7 +1,12 @@
 class Api::V1::Demographics::StateController < Api::ApiController
   respond_to :json
 
+  # def show
+  #   respond_with State.new(params[:year])
+  # end
+
   def show
-    respond_with State.new(params[:year])
+    message, options = response_path(State.new(params[:year]), StateSerializer, params)
+    respond_with message, options
   end
 end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -1,12 +1,20 @@
 class State
-  def self.total_students_in_school_year(years)
+  include ActiveModel::Serialization
+
+  attr_reader :years
+
+  def initialize(years)
+    @years = years
+  end
+
+  def total_students_in_school_year(years)
     school_year = SchoolYear.find_by(years: years)
     DistrictSchoolYear.joins(:student_enrollment)
                       .where(school_year_id: school_year.id)
                       .sum('student_enrollments.total')
   end
 
-  def self.number_and_percent_students_of_demographic_in_school_year(years, student_identifier_name)
+  def number_and_percent_students_of_demographic_in_school_year(years, student_identifier_name)
     school_year = SchoolYear.find_by(years: years)
     total_students_of_demographic_in_year = PopulationDemographic.joins(:student_identifier, :district_school_year)
                          .where(student_identifiers: { name: student_identifier_name }, district_school_years: {school_year_id: school_year.id})

--- a/app/serializers/state_serializer.rb
+++ b/app/serializers/state_serializer.rb
@@ -1,0 +1,18 @@
+class StateSerializer < ActiveModel::Serializer
+  attributes :demographics
+
+  def demographics
+    all_tags = []
+    Tag.all.each do |tag|
+      unless tag.name == "all"
+        custom_tag = {tag.name => {}}
+        tag.student_identifiers.each do |si|
+          number, percent = object.number_and_percent_students_of_demographic_in_school_year(object.years, si.name)
+          custom_tag[tag.name][si.name] = { number: number, percent: percent }
+        end
+        all_tags.push(custom_tag)
+      end
+    end
+    all_tags
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       get '/districts',                      to: 'districts#index'
       get '/counties',                       to: 'counties#index'
       get '/demographics/district-in-year',  to: 'demographics/districts#show'
+      get '/demographics/statewide',         to: 'demographics/state#show'
       get '/graduation/district-in-year',    to: 'graduation/districts#show'
       get '/graduation/county-in-year',      to: 'graduation/counties#show'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       get '/districts',                      to: 'districts#index'
       get '/counties',                       to: 'counties#index'
       get '/demographics/district-in-year',  to: 'demographics/districts#show'
-      get '/demographics/statewide',         to: 'demographics/state#show'
+      get '/demographics/statewide-in-year',         to: 'demographics/state#show'
       get '/graduation/district-in-year',    to: 'graduation/districts#show'
       get '/graduation/county-in-year',      to: 'graduation/counties#show'
     end

--- a/lib/swagger/swagger_v1.json
+++ b/lib/swagger/swagger_v1.json
@@ -218,6 +218,76 @@
                 }
             }
         },
+        "/demographics/statewide-in-year": {
+            "get": {
+                "summary": "Student demographics for specified district in given year",
+                "description": "This endpoint returns the gender, race & ethnicity, students who receive exceptional student services, and other demographic information on all students in Washington State. The school year should be passed as the full year for the starting year, and the last two digits of the ending year. This can only span one school year. For example - '2016-17'. The state has provided slightly different data for each school year, so there may be some empty values. NOTE: if the number in foster care is -10, that means that the district provided a result of 'N<10'",
+                "parameters": [
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "description": "school year for which data is being requested",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "api_key",
+                        "in": "query",
+                        "description": "your individual api key",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "tags": [
+                    "State",
+                    "Demographics"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful response",
+                        "schema": {
+                            "$ref": "#/definitions/StateDemographics"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "description": "contains error message and status code",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "unauthorized error"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "description": "401 status code"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Data does not exist for the school year. Includes specifics for which parameter could not be found",
+                        "schema": {
+                            "type": "object",
+                            "description": "contains error message and status code",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "specific error"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "description": "404 status code"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/graduation/district-in-year": {
             "get": {
                 "summary": "Five year graduation rates for the specified school district and year",
@@ -799,6 +869,268 @@
                         "students_per_classroom_teacher": {
                             "type": "integer",
                             "description": "Average number of students per classroom teacher"
+                        }
+                    }
+                }
+            }
+        },
+        "StateDemographics": {
+            "type": "object",
+            "properties": {
+                "demographics": {
+                    "type": "array",
+                    "description": "All student demographics for given district and school year",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "gender": {
+                                "type": "object",
+                                "description": "gender demographics",
+                                "properties": {
+                                    "male": {
+                                        "type": "object",
+                                        "description": "number and percent of male students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of male students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are male"
+                                            }
+                                        }
+                                    },
+                                    "female": {
+                                        "type": "object",
+                                        "description": "number and percent of female students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of female students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are female"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "race ethnicity": {
+                                "type": "object",
+                                "description": "All student race ethnicity demographics",
+                                "properties": {
+                                    "american indian or alaskan native": {
+                                        "type": "object",
+                                        "description": "number and percent of American Indian or Alaskan Native students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of American Indian or Alaskan Native students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are American Indian or Alaskan Native"
+                                            }
+                                        }
+                                    },
+                                    "asian": {
+                                        "type": "object",
+                                        "description": "number and percent of Asian students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of Asian students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are Asian"
+                                            }
+                                        }
+                                    },
+                                    "asian pacific islander": {
+                                        "type": "object",
+                                        "description": "number and percent of Asian Pacific Islander students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of Asian Pacific Islander students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are Asian Pacific Islander"
+                                            }
+                                        }
+                                    },
+                                    "black or african american": {
+                                        "type": "object",
+                                        "description": "number and percent of Black or African American students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of Black or African American students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are Black or African American"
+                                            }
+                                        }
+                                    },
+                                    "hispanic or latino": {
+                                        "type": "object",
+                                        "description": "number and percent of Hispanic or Latino students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of Hispanic or Latino students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are Hispanic or Latino"
+                                            }
+                                        }
+                                    },
+                                    "pacific islander": {
+                                        "type": "object",
+                                        "description": "number and percent of Pacific Islander students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of Pacific Islander students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are Pacific Islander"
+                                            }
+                                        }
+                                    },
+                                    "two or more races": {
+                                        "type": "object",
+                                        "description": "number and percent of students who are two or more races",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students in district who are two or more races"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are two or more races"
+                                            }
+                                        }
+                                    },
+                                    "white": {
+                                        "type": "object",
+                                        "description": "number and percent of White students",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of White students in district"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students in district who are White"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "other": {
+                                "type": "object",
+                                "description": "other demographic indicators",
+                                "properties": {
+                                    "foster care": {
+                                        "type": "object",
+                                        "description": "number and percent of students who are in foster care",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students who are in foster care"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students who are in foster care"
+                                            }
+                                        }
+                                    },
+                                    "free or reduced price lunch": {
+                                        "type": "object",
+                                        "description": "number and percent of students who receive free or reduced price lunch",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students who receive free or reduced price lunch"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students who receive free or reduced price lunch"
+                                            }
+                                        }
+                                    },
+                                    "transitional bilingual": {
+                                        "type": "object",
+                                        "description": "number and percent of students who are transitional bilingual",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students who are transitional bilingual"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students who are transitional bilingual"
+                                            }
+                                        }
+                                    },
+                                    "title i migrant": {
+                                        "type": "object",
+                                        "description": "number and percent of students who are Title I Migrant",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students who are Title I Migrant"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students who are Title I Migrant"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "exceptional student services": {
+                                "type": "object",
+                                "description": "other demographic indicators",
+                                "properties": {
+                                    "section 504": {
+                                        "type": "object",
+                                        "description": "number and percent of students who have section 504 plans",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students who have section 504 plans"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students who have section 504 plans"
+                                            }
+                                        }
+                                    },
+                                    "special education": {
+                                        "type": "object",
+                                        "description": "number and percent of students who receive special education services",
+                                        "properties": {
+                                            "number": {
+                                                "type": "integer",
+                                                "description": "number of students who receive special education services"
+                                            },
+                                            "percent": {
+                                                "type": "integer",
+                                                "description": "percent of students who receive special education services"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/spec/controller/demographics/state_controller_spec.rb
+++ b/spec/controller/demographics/state_controller_spec.rb
@@ -14,4 +14,31 @@ RSpec.describe Api::V1::Demographics::StateController, type: :controller do
     expect(state_demographics["demographics"][2]["other"]).to be_truthy
     expect(state_demographics["demographics"][3]["gender"]).to be_truthy
   end
+
+  it "responds with error if school year doesn't exist" do
+    user = User.create(email: "example@example.com", password: "password", api_key: "abc123")
+    create_district_and_demographic_data
+
+    get :show, year: "2014-15", api_key: user.api_key, format: :json
+
+    expected_response = {
+      message: "We do not have data for that school year. Please try another query.",
+      status: 404
+    }.to_json
+
+    expect(response.body).to eq(expected_response)
+    expect(response.code).to eq("404")
+  end
+
+  it "requires a valid API key" do
+    school_year, _, _, district = create_district_and_demographic_data
+
+
+    get :show, year: school_year.years, format: :json
+
+    expected_response = { message: "Please include a valid API key with your request", status: 401 }.to_json
+
+    expect(response.code).to eq("401")
+    expect(expected_response).to eq(response.body)
+  end
 end

--- a/spec/controller/demographics/state_controller_spec.rb
+++ b/spec/controller/demographics/state_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Demographics::StateController, type: :controller do
+  it "returns data statewide" do
+    user = User.create(email: "example@example.com", password: "password", api_key: "abc123")
+
+    school_year, _ = create_district_and_demographic_data
+
+    get :show, year: school_year.years, api_key: user.api_key, format: :json
+    state_demographics = JSON.parse(response.body)
+
+    expect(state_demographics["demographics"][0]["race ethnicity"]).to be_truthy
+    expect(state_demographics["demographics"][1]["exceptional student services"]).to be_truthy
+    expect(state_demographics["demographics"][2]["other"]).to be_truthy
+    expect(state_demographics["demographics"][3]["gender"]).to be_truthy
+  end
+end

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe State, type: :model do
     student_enrollment2 = StudentEnrollment.create(total: 2475, students_per_classroom_teacher: 18)
     DistrictSchoolYear.create(district_id: district2.id, school_year_id: school_year.id, student_enrollment_id: student_enrollment2.id)
 
-    expect(State.total_students_in_school_year("2015-16")).to eq(3853)
+    expect(State.new("2015-16").total_students_in_school_year("2015-16")).to eq(3853)
   end
 
   it "finds the number and percent of students of specific demographic in state in school year" do
     create_district_and_demographic_data
-    total, percent = State.number_and_percent_students_of_demographic_in_school_year("2015-16", "white")
+    total, percent = State.new("2015-16").number_and_percent_students_of_demographic_in_school_year("2015-16", "white")
     expect(total).to eq(145)
     expect(percent).to eq(10.52)
   end


### PR DESCRIPTION
Creates endpoint returning statewide averages on demographic data. Uses State PORO - is not persistent in database. Formatted similarly to district and county endpoints.