### PR TITLE
Graduation rake debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The production app can be found [here](https://wadoe-api.herokuapp.com/) - this 
 1. Clone down the repository
 2. From the project directory:
   * `bundle`
-  * `rake db:create db:migrate db:import_demographic_data db:import_graduation_data db:import_county_graduation_data`
+  * `rake db:create db:migrate db:create_tags_and_identifiers db:import_demographic_data db:import_graduation_data db:import_county_graduation_data`
 
 ### Testing
 

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-american_indian_or_alaskan_native.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-american_indian_or_alaskan_native.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,23,4,0,1,1,0,4,12,15,9,0,60.0,40.0,0.0
 2010-11,21226,Adna,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,29103,Anacortes,3,2,0,0,0,0,1,1,4,2,1,50.0,25.0,25.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-asian.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-asian.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,12,3,0,1,0,1,1,5,10,7,0,70.0,30.0,0.0
 2010-11,21226,Adna,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,29103,Anacortes,13,6,0,0,0,0,0,6,13,13,0,100.0,0.0,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-asian_pacific_islander.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-asian_pacific_islander.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,12,4,0,1,0,1,1,6,10,7,0,70.0,30.0,0.0
 2010-11,21226,Adna,1,2,0,0,0,0,0,1,2,2,0,100.0,0.0,0.0
 2010-11,29103,Anacortes,13,7,0,0,0,0,0,6,14,14,0,100.0,0.0,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-black_or_african_american.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-black_or_african_american.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,5,1,0,0,0,0,0,4,2,2,0,100.0,0.0,0.0
 2010-11,21226,Adna,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,29103,Anacortes,3,1,0,0,0,0,0,1,3,3,0,100.0,0.0,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-female.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-female.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,183,36,1,7,10,11,8,74,145,107,1,73.8,25.5,0.7
 2010-11,21226,Adna,21,10,0,0,2,0,0,13,18,16,0,88.9,11.1,0.0
 2010-11,29103,Anacortes,121,41,0,3,2,3,4,51,111,98,1,88.3,10.8,0.9

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-free_or_reduced_price_lunch.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-free_or_reduced_price_lunch.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,199,65,2,10,15,22,24,95,169,89,7,52.7,43.2,4.1
 2010-11,21226,Adna,24,12,1,0,2,0,0,20,16,13,0,81.3,18.8,0.0
 2010-11,29103,Anacortes,95,21,1,0,5,8,7,41,75,50,4,66.7,28.0,5.3

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-hispanic_or_latino.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-hispanic_or_latino.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,40,10,2,1,2,1,5,17,33,21,1,63.6,33.3,3.0
 2010-11,21226,Adna,1,0,0,0,0,0,0,0,1,1,0,100.0,0.0,0.0
 2010-11,29103,Anacortes,9,5,0,0,0,1,1,6,8,6,0,75.0,25.0,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-male.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-male.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,ContinuingAdjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,169,56,2,3,10,12,23,82,143,85,8,59.4,35.0,5.6
 2010-11,21226,Adna,31,16,1,0,0,0,0,21,26,25,0,96.2,3.8,0.0
 2010-11,29103,Anacortes,129,31,1,0,5,14,6,52,108,77,5,71.3,24.1,4.6

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-male.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-male.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,ContinuingAdjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,169,56,2,3,10,12,23,82,143,85,8,59.4,35.0,5.6
 2010-11,21226,Adna,31,16,1,0,0,0,0,21,26,25,0,96.2,3.8,0.0
 2010-11,29103,Anacortes,129,31,1,0,5,14,6,52,108,77,5,71.3,24.1,4.6

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-pacific_islander.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-pacific_islander.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,21226,Adna,1,1,0,0,0,0,0,0,2,2,0,100.0,0.0,0.0
 2010-11,29103,Anacortes,0,1,0,0,0,0,0,0,1,1,0,100.0,0.0,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-section_504.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-section_504.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,1,0,0,0,0,0,0,0,1,1,0,100.0,0.0,0.0
 2010-11,21226,Adna,1,0,0,0,0,0,0,0,1,1,0,100.0,0.0,0.0
 2010-11,29103,Anacortes,7,0,0,0,0,1,0,1,6,5,0,83.3,16.7,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-special_education.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-special_education.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,37,14,1,3,2,6,6,23,28,8,2,28.6,64.3,7.1
 2010-11,21226,Adna,6,4,0,0,0,0,0,7,3,3,0,100.0,0.0,0.0
 2010-11,29103,Anacortes,27,7,1,0,2,3,1,14,20,11,2,55.0,35.0,10.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-title_i_migrant.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-title_i_migrant.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,13,1,0,0,2,1,0,6,8,5,0,62.5,37.5,0.0
 2010-11,21226,Adna,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,29103,Anacortes,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-transitional_bilingual.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-transitional_bilingual.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,20,1,1,1,2,0,3,7,14,6,1,42.9,50.0,7.1
 2010-11,21226,Adna,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,29103,Anacortes,5,0,0,0,0,0,0,3,2,2,0,100.0,0.0,0.0

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-two_or_more_races.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-two_or_more_races.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,6,1,0,0,0,1,0,5,2,1,0,50.0,50.0,0.0
 2010-11,21226,Adna,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a
 2010-11,29103,Anacortes,0,0,0,0,0,0,0,0,0,0,0,n/a,n/a,n/a

--- a/app/assets/data/graduation-district/2010-11-5YearGraduation-white.csv
+++ b/app/assets/data/graduation-district/2010-11-5YearGraduation-white.csv
@@ -1,4 +1,4 @@
-SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted Actual 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
+SchoolYear,Dist,District,Beginning Grade 9 Students,Transferred In,Dropouts Year 1,Dropouts Year 2,Dropouts Year 3,Dropouts Year 4,Dropouts Year 5,Transferred Out,Adjusted Cohort,Graduates,Continuing,Adjusted 5-Year Cohort Graduation Rate,Cohort dropout rate,Continuing Rate
 2010-11,14005,Aberdeen,266,72,1,7,17,20,21,112,226,152,8,67.3,29.2,3.5
 2010-11,21226,Adna,50,21,1,0,2,0,0,30,41,38,0,92.7,7.3,0.0
 2010-11,29103,Anacortes,221,57,1,3,7,16,8,88,190,150,5,78.9,18.4,2.6

--- a/app/serializers/object_school_year_serializer.rb
+++ b/app/serializers/object_school_year_serializer.rb
@@ -37,7 +37,7 @@ module ObjectSchoolYearSerializer
 
   def all_tags_response
     all_tags = []
-    object.tags.each do |tag|
+    Tag.all.each do |tag|
       custom_tag = {tag.name => {}}
       tag.student_identifiers.each do |si|
         add_statistics_to_tag(custom_tag, si, tag)

--- a/lib/tasks/import-district-graduation.rake
+++ b/lib/tasks/import-district-graduation.rake
@@ -86,7 +86,7 @@ namespace :db do
                        year_4: row["Dropouts Year 4"].to_i,
                        year_5: row["Dropouts Year 5"].to_i,
         )
-        district = District.find_by(number: row["Dist"].to_i)
+        district = District.find_by(number: row["Dist"])
         school_year = SchoolYear.find_or_create_by(years: row["SchoolYear"])
         if district
           district_school_year = DistrictSchoolYear.find_or_create_by(district_id: district.id, school_year_id: school_year.id)

--- a/spec/controller/graduation/counties_controller_spec.rb
+++ b/spec/controller/graduation/counties_controller_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Api::V1::Graduation::CountiesController, type: :controller do
       county_graduation = JSON.parse(response.body)
 
       expect(county_graduation["graduation"]).to be_truthy
-      expect(county_graduation["graduation"][1]["race ethnicity"]["asian"]["transferred_out"]).to be_truthy
-      expect(county_graduation["graduation"][3]["exceptional student services"]).to be_truthy
+      expect(county_graduation["graduation"][0]["race ethnicity"]["asian"]["transferred_out"]).to be_truthy
+      expect(county_graduation["graduation"][1]["exceptional student services"]).to be_truthy
       expect(county_graduation["graduation"][4]["all"]).to be_truthy
       expect(county_graduation["graduation"][2]["other"]).to be_truthy
-      expect(county_graduation["graduation"][0]["gender"]).to be_truthy
+      expect(county_graduation["graduation"][3]["gender"]).to be_truthy
       expect(response.code).to eq("200")
     end
 

--- a/spec/controller/graduation/districts_controller_spec.rb
+++ b/spec/controller/graduation/districts_controller_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Api::V1::Graduation::DistrictsController, type: :controller do
       district_demographics = JSON.parse(response.body)
 
       expect(district_demographics["graduation"]).to be_truthy
-      expect(district_demographics["graduation"][1]["race ethnicity"]["asian"]["transferred_out"]).to be_truthy
-      expect(district_demographics["graduation"][3]["exceptional student services"]).to be_truthy
+      expect(district_demographics["graduation"][0]["race ethnicity"]["asian"]["transferred_out"]).to be_truthy
+      expect(district_demographics["graduation"][1]["exceptional student services"]).to be_truthy
       expect(district_demographics["graduation"][4]["all"]).to be_truthy
       expect(district_demographics["graduation"][2]["other"]).to be_truthy
-      expect(district_demographics["graduation"][0]["gender"]).to be_truthy
+      expect(district_demographics["graduation"][3]["gender"]).to be_truthy
       expect(response.code).to eq("200")
     end
 


### PR DESCRIPTION
In rake task, look up district by number as string to match schema instead of integer - was dropping leading zeros
In serializer: go through all tasks to eliminate need for relationship between a tag and a district school year object
In 2010-11 district graduation csv, update column header to match other files and rake task